### PR TITLE
Fixes a crash of the run_QDNAseq script, when a bamfile is large.

### DIFF
--- a/scripts/run_QDNAseq.R
+++ b/scripts/run_QDNAseq.R
@@ -21,7 +21,7 @@ data("b5.cl80")
 bins <- b5.cl80
 
 #Open bam files and get read counts
-readCounts <- binReadCounts(bins, bams, cache=F)
+readCounts <- binReadCounts(bins, bams, cache=F, chunkSize=100000000)
 
 # Filter optimisation
 if (!file.exists("readCountsFiltered.rds")) {


### PR DESCRIPTION
The run_QDNAseq script crashes on large bamfiles. (Tested on a 90x bamfile)

```   PMRBM000AIO_dedup (1 of 1): extracting reads ...Error in value[[3L]](cond) :
  'Realloc' could not re-allocate memory (18446744065128005632 bytes)
  file: /hpc/pmc_vanboxtel/processed/Dilys_IAP_test/output/PMRBM000AIO/mapping/PMRBM000AIO_dedup.bam
  index: NA
Calls: binReadCounts ... tryCatch -> tryCatchList -> tryCatchOne -> <Anonymous>
Execution halted
```

This problem is solved by using the `chunkSize` argument of `binReadCounts`, which allows the bamfile to be processed in chunks.

A similar error is discussed here:
https://support.bioconductor.org/p/53015/