### PR TITLE
Fixed sample name reading of makeBAFplot.R

### DIFF
--- a/scripts/makeBAFplot.R
+++ b/scripts/makeBAFplot.R
@@ -9,9 +9,9 @@ outdir <- args[6]
 print(outdir)
 baffile <- args[7]
 print(baffile)
-sample <- unlist(strsplit(baffile,"/"))
+sample <- gsub(".*/", "", baffile)
 print(sample)
-sample <- unlist(strsplit(sample[length(sample)],"_"))[1]
+sample <- gsub("_BAF.txt", "", sample)
 print(sample)
 
 f2 <- function(x) sum(unlist(x)[2:length(x)])


### PR DESCRIPTION
When a previously mapped bamfile is used, its sample name will contain '_dedup'. 
makeBAFplot.R now no longer removes this part of the sample name, resulting in a pdf output whose filename is consistent with the other BAF files. This also allows the result to be correctly moved from the tmp directory to the output directory.